### PR TITLE
Fix installation.md path

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -59,7 +59,7 @@ cp templates/LICENSE "$EXPORT_LOCATION/LICENSE"
 print_success "  [OK]"
 
 print_info "  Copying installation instructions..."
-sed "$REPLACE_TEMPLATE_VARS" templates/Installation.md > "$EXPORT_LOCATION/Installation.md"
+sed "$REPLACE_TEMPLATE_VARS" templates/Installation.md > "$EXPORT_LOCATION/docs/Installation.md"
 print_success "  [OK]"
 
 print_info "  Copying source code format properties file..."


### PR DESCRIPTION
Installation.md was being referenced from the main README.md as if it were on docs/Installation.md but it was on the root directory