### PR TITLE
Fixes #7 and #8

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -36,7 +36,7 @@ if [ -d "$EXPORT_LOCATION" ]; then
   rm --recursive --force "$EXPORT_LOCATION"
 fi
 print_info "  Creating base directories..."
-mkdir --parents "$EXPORT_LOCATION"/{assets/logos,source,docs}
+mkdir -p "$EXPORT_LOCATION"/{assets/logos,source,docs}
 print_success "  [OK]"
 
 readonly REPLACE_TEMPLATE_VARS="

--- a/templates/.travis.yml
+++ b/templates/.travis.yml
@@ -6,11 +6,6 @@ smalltalk:
 - Pharo64-7.0
 - Pharo-7.0
 - Pharo-6.1
-matrix:
-  allow_failures:
-  - smalltalk: Pharo64-7.0
-  - smalltalk: Pharo-7.0
-  fast_finish: true
 before_deploy:
   - cp "${SMALLTALK_CI_IMAGE}" "<PROJECT_NAME>.image"
   - cp "${SMALLTALK_CI_CHANGES}" "<PROJECT_NAME>.changes"
@@ -22,5 +17,5 @@ deploy:
   file: "${TRAVIS_BRANCH}-${TRAVIS_SMALLTALK_VERSION}.zip"
   skip_cleanup: true
   on:
-    repo: ba-st/<REPO_NAME>
+    repo: <OWNER>/<REPO_NAME>
     tags: true


### PR DESCRIPTION
- Use `-p` instead of `--parents`
- Changed travis template
  - Don't allow to fail anymore Pharo 7 builds
  - Consider OWNER argument in the deployment section

Fixes #7 and #8