### PR TITLE
Upgrade GH Actions versions

### DIFF
--- a/.github/workflows/markdown-lint.yml
+++ b/.github/workflows/markdown-lint.yml
@@ -5,9 +5,9 @@ jobs:
     name: runner / markdownlint
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: markdownlint
-        uses: reviewdog/action-markdownlint@v0.1
+        uses: reviewdog/action-markdownlint@v0
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           fail_on_error: true

--- a/.github/workflows/shellcheck.yml
+++ b/.github/workflows/shellcheck.yml
@@ -1,12 +1,10 @@
 name: Shellcheck
-
 on: [push,pull_request]
-
 jobs:
   shellcheck:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Run Shellcheck
         uses: reviewdog/action-shellcheck@v1
         with:

--- a/templates/.github/workflows/loading-groups.yml
+++ b/templates/.github/workflows/loading-groups.yml
@@ -12,7 +12,7 @@ jobs:
         load-spec: [ deployment, dependent-sunit-extensions, tests, tools, development ]
     name: ${{ matrix.smalltalk }} + ${{ matrix.load-spec }}
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: hpi-swa/setup-smalltalkCI@v1
         with:
           smalltalk-image: ${{ matrix.smalltalk }}

--- a/templates/.github/workflows/markdown-lint.yml
+++ b/templates/.github/workflows/markdown-lint.yml
@@ -5,9 +5,9 @@ jobs:
     name: runner / markdownlint
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: markdownlint
-        uses: reviewdog/action-markdownlint@v0.1
+        uses: reviewdog/action-markdownlint@v0
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           fail_on_error: true

--- a/templates/.github/workflows/unit-tests.yml
+++ b/templates/.github/workflows/unit-tests.yml
@@ -10,7 +10,7 @@ jobs:
         smalltalk: [ Pharo64-10, Pharo64-9.0 ]
     name: ${{ matrix.smalltalk }}
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Set up Smalltalk CI
         uses: hpi-swa/setup-smalltalkCI@v1
         with:


### PR DESCRIPTION
- Upgrade checkout action version from v2 to v3
- Change markdown lint action version from v0.1 to v0